### PR TITLE
feat: add xs size to icon and use in icon button

### DIFF
--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -38,7 +38,7 @@ export const IconButton = <
 			/* eslint-disable-next-line */
 			{...(props as any)}
 			className={classnames(' flex items-center gap-xxs transition-colors duration-300 mb-font-label-s', colorClasses)}>
-			{<Icon size={'s'} color={'inherit'} />}
+			{<Icon size={'xs'} color={'inherit'} />}
 			<span>{children}</span>
 		</LinkComponent>
 	);

--- a/src/components/icons/iconUtils.ts
+++ b/src/components/icons/iconUtils.ts
@@ -1,5 +1,7 @@
-export const getSizeClass = (size?: 's' | 'm' | 'l') => {
+export const getSizeClass = (size?: 'xs' | 's' | 'm' | 'l') => {
 	switch (size) {
+		case 'xs':
+			return 'w-s h-s pl-xxs -ml-xxs';
 		case 's':
 			return 'w-s h-s';
 		case 'm':
@@ -31,7 +33,7 @@ export const getColorClass = (color?: 'base' | 'white' | 'primary' | 'secondary'
 };
 
 export interface IconProps {
-	size?: 's' | 'm' | 'l';
+	size?: 'xs' | 's' | 'm' | 'l';
 	color?: 'base' | 'white' | 'primary' | 'secondary' | 'error' | 'inherit';
 }
 


### PR DESCRIPTION
The icon in the icon button doesn't match the figma design (of mumble) but is a little too big.

This PR introduces icon size XS and uses it in the icon button.