### PR TITLE
feat: never disable comment button

### DIFF
--- a/src/components/comment-button/comment-button.tsx
+++ b/src/components/comment-button/comment-button.tsx
@@ -39,7 +39,6 @@ export const CommentButton: React.FC<CommentButtonProps> = ({ count, hasCommente
 			isToggled={hasCommented}
 			onClick={handleCommentClick}
 			color="primary"
-			disabled={hasCommented}
 			useToggledColor={false}
 			icon={<ReplyIcon size="s" color="base" />}
 			hoveredIcon={<ReplyIcon size="s" color="primary" />}


### PR DESCRIPTION
This is just to not disable the comment button when logged in user has already commented: the link should still work and the user can of course add a second comment.