### PR TITLE
feat: always allow click

### DIFF
--- a/src/components/comment-button/comment-button.tsx
+++ b/src/components/comment-button/comment-button.tsx
@@ -28,9 +28,7 @@ export const CommentButton: React.FC<CommentButtonProps> = ({ count, hasCommente
 	const label = getCommentText(count, labels);
 
 	const handleCommentClick = () => {
-		if (!hasCommented) {
-			onClick();
-		}
+		onClick();
 	};
 
 	return (


### PR DESCRIPTION
This is the second part of what was supposed to be a small fix. The click handler was prevented from firing even though the button was not disabled anymore. this is wrong.